### PR TITLE
Vagrantfile/build: update to ubuntu/bionic64 and remove docker-ce

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # based on offical ubuntu server 16.04 LTS (Xenial Xerus) builds
-  config.vm.box = "ubuntu/xenial64"
+  # based on Official Ubuntu 18.04 LTS (Bionic Beaver) Daily Build
+  config.vm.box = "ubuntu/bionic64"
 
   # provided by virtualbox
   #

--- a/build/install_tools.sh
+++ b/build/install_tools.sh
@@ -56,16 +56,6 @@ install_golang() {
   curl -sSL "${target}" | sudo tar -v -C /usr/local -xz
 }
 
-# install_docker_ce installs docker-ce
-install_docker_ce() {
-  sudo apt-get install docker-ce -y
-
-  # fix the damn "Permission denied" issue
-  #
-  # NOTE: need to log-out and log-in to make new group member into effect.
-  sudo gpasswd -a "${USER}" docker
-}
-
 # install_dotfiles installs from github.com/fuweid/dotfiles.
 #
 # FIXME(fuweid): if we don't use yes command to do confirm, the scripts will
@@ -99,7 +89,6 @@ install_fzf() {
 main() {
   install_base
   install_golang
-  install_docker_ce
   install_dotfiles
   install_fzf
 }

--- a/build/pkg_mgmt.sh
+++ b/build/pkg_mgmt.sh
@@ -11,20 +11,20 @@ export DEBIAN_FRONTEND=noninteractive
 
 # setup_mirror_source uses mirror package source instead of default value.
 #
-# NOTE: use mirror.tuna.tsinghua.edu.cn 16.04 LTS because of GFW.
+# NOTE: use mirror.tuna.tsinghua.edu.cn 18.04 LTS because of GFW.
 setup_mirror_source() {
   sudo cp /etc/apt/sources.list /etc/apt/sources.list.old
 
   cat <<-EOF | sudo tee /etc/apt/sources.list
 # mirror tsinghua.edu.cn
-deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial main restricted universe multiverse
-deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial main restricted universe multiverse
-deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse
-deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse
-deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse
-deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse
-deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse
-deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse
+deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic main restricted universe multiverse
+# deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic main restricted universe multiverse
+deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-updates main restricted universe multiverse
+# deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-updates main restricted universe multiverse
+deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-backports main restricted universe multiverse
+# deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-backports main restricted universe multiverse
+deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-security main restricted universe multiverse
+# deb-src https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ bionic-security main restricted universe multiverse
 EOF
 
   # add docker repo source
@@ -33,25 +33,6 @@ EOF
 
 # setup_third_party_sources adds third party sources into source.list.d.
 setup_third_party_sources() {
-  # add Docker repo source
-  # from https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-docker-ce
-
-  # allow apt to use a repository over HTTPS
-  sudo apt-get install -y \
-    curl \
-    ca-certificates \
-    apt-transport-https \
-    software-properties-common \
-    --no-install-recommends
-
-  # add Docker’s official GPG key
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-
-  cat <<-EOF | sudo tee /etc/apt/sources.list.d/docker.list
-# docker-ce
-deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable
-EOF
-
   # add neovim repo source
   #
   # NOTE: only support versions >= 16.04!!!


### PR DESCRIPTION
There is block issue to use fzf with preview fzf#1486. That is why I
need to upgrade the release of ubuntu. And the docker-ce apt-source
doesn't work well right. Maybe it is impacted by the GFW. Anyway, I will
add that back if the file fetch can work well.

Signed-off-by: Wei Fu <fuweid89@gmail.com>