### PR TITLE
Vagrantfile: allow ENV value to config cpu/memory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,12 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+# by default, the cpu number of vm is 4.
+cpu_number = ENV["VM_CPU_NUMBER"] || 4
+
+# by default, the memory of vm is 4GB.
+memory_limit = ENV["VM_MEMORY_LIMIT"] || 4096
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # based on Official Ubuntu 18.04 LTS (Bionic Beaver) Daily Build
   config.vm.box = "ubuntu/bionic64"
@@ -9,12 +15,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # provided by virtualbox
   #
   # - headless bootup
-  # - 4 cpu number
-  # - 4GB memory
+  # - 4 cpu number or the value by env VM_CPU_NUMBER
+  # - 4GB memory or the value by env VM_MEMORY_LIMIT
   config.vm.provider "virtualbox" do |vb|
     vb.gui    = false
-    vb.cpus   = 4
-    vb.memory = 4096
+    vb.cpus   = cpu_number
+    vb.memory = memory_limit
   end
 
   # setup package source


### PR DESCRIPTION
Yeah. Hate the fixed configuration.

Signed-off-by: Wei Fu <fuweid89@gmail.com>