### PR TITLE
build: source zshrc before clone_github_projects

### DIFF
--- a/build/clone_github_projects.sh
+++ b/build/clone_github_projects.sh
@@ -2,6 +2,9 @@
 #
 # clone github projects
 
+# golang related setting is in zshrc
+source ~/.zshrc
+
 set -euo pipefail
 
 # fetch_go_projects clones golang projects.


### PR DESCRIPTION
The golang related env setting is in zshrc. Since vagrant doesn't
relogin for each provision script, we need source the zshrc before
running clone things.

Signed-off-by: Wei Fu <fuweid89@gmail.com>